### PR TITLE
Make tests EBU-TT-D compatible

### DIFF
--- a/fail/dur001-fail.ttml
+++ b/fail/dur001-fail.ttml
@@ -2,13 +2,21 @@
 <!-- Available rendering time exceeded due to glyph drawing (CJK) -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="185%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
   </head>
   <body>
-    <div>
-      <p begin="2.5s" end="3s" tts:fontSize="185%">a</p>
-      <p begin="3s" end="4s" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p xml:id="p0" begin="00:00:02.5" end="00:00:03" style="s0">a</p>
+      <p xml:id="p1" begin="00:00:03" end="00:00:04" style="s0">あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/fail/dur002-fail.ttml
+++ b/fail/dur002-fail.ttml
@@ -2,13 +2,21 @@
 <!-- Available rendering time exceeded due to glyph copy -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
-  <head>
-  </head>
-  <body>
-    <div>
-      <p begin="2.5s" end="3s">z</p>
-      <p begin="3s" end="4s" tts:fontSize="300%">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</p>
-    </div>
-  </body>
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+<head>
+  <styling>
+    <style xml:id="s1" tts:fontSize="300%"/>
+  </styling>
+  <layout>
+    <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+  </layout>
+</head>
+<body>
+  <div region="r0">
+    <p xml:id="p0" begin="00:00:02.5" end="00:00:03">z</p>
+    <p xml:id="p1" begin="00:00:03" end="00:00:04" style="s1">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</p>
+  </div>
+</body>
 </tt>

--- a/fail/dur003-fail.ttml
+++ b/fail/dur003-fail.ttml
@@ -2,18 +2,21 @@
 <!-- Available rendering time exceeded due to background drawing -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
     <styling>
-      <style xml:id="s1" tts:backgroundColor="red" />
+      <style xml:id="s1" tts:backgroundColor="#ff0000" />
     </styling>
     <layout>
-      <region xml:id="r1" style="s1"/>
+      <region xml:id="r1" tts:origin="0% 0%" tts:extent="100% 100%" style="s1"></region>
     </layout>
   </head>
   <body>
     <div>
-      <p region="r1" begin="3s" end="4s"><span style="s1">a</span><span style="s1">b</span><span style="s1">c</span><span style="s1">d</span></p>
+      <p xml:id="p0" begin="00:00:02.5" end="00:00:03">a</p>
+      <p xml:id="p1" region="r1" begin="00:00:03" end="00:00:04"><span style="s1">a</span><span style="s1">b</span><span style="s1">c</span><span style="s1">d</span></p>
     </div>
   </body>
 </tt>

--- a/fail/dur003-fail.ttml
+++ b/fail/dur003-fail.ttml
@@ -15,7 +15,6 @@
   </head>
   <body>
     <div>
-      <p xml:id="p0" begin="00:00:02.5" end="00:00:03">a</p>
       <p xml:id="p1" region="r1" begin="00:00:03" end="00:00:04"><span style="s1">a</span><span style="s1">b</span><span style="s1">c</span><span style="s1">d</span></p>
     </div>
   </body>

--- a/fail/dur004-fail.ttml
+++ b/fail/dur004-fail.ttml
@@ -2,13 +2,21 @@
 <!-- Available rendering time exceeded due to glyph copy (CJK) -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
+    <styling>
+      <style xml:id="s1" tts:fontSize="300%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
   </head>
   <body>
-    <div>
-      <p begin="2.5s" end="3s" tts:fontSize="300%">a</p>
-      <p begin="3s" end="4s" tts:fontSize="300%">ああああああああああああああああああああああああああああ</p>
+    <div region="r0">
+      <p xml:id="p0" begin="00:00:02.5" end="00:00:03" style="s1">a</p>
+      <p xml:id="p1" begin="00:00:03" end="00:00:04" style="s1">ああああああああああああああああああああああああああああ</p>
     </div>
   </body>
 </tt>

--- a/fail/dur005-fail.ttml
+++ b/fail/dur005-fail.ttml
@@ -2,10 +2,12 @@
 <!-- Available rendering time exceeded due to glyph drawing and background drawing (multi-region) -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
     <styling>
-      <style xml:id="s1" tts:backgroundColor="red" />
+      <style xml:id="s1" tts:backgroundColor="#ff0000" />
     </styling>
     <layout>
       <region xml:id="r1" style="s1" tts:extent="50% 50%" tts:origin="0% 0%"/>
@@ -16,11 +18,11 @@
   </head>
   <body>
     <div>
-      <p region="r4" begin="0s" end="0.2s">ABCDEF</p>
-      <p region="r1" begin="0.31s" end="4s"><span style="s1">abcdef</span></p>
-      <p region="r2" begin="0.31s" end="4s"><span style="s1">ghijkl</span></p>
-      <p region="r3" begin="0.31s" end="4s"><span style="s1">mnopqr</span></p>
-      <p region="r4" begin="0.31s" end="4s"><span style="s1">stuvwy</span></p>
+      <p region="r4" begin="00:00:00" end="00:00:00.2" xml:id="p0">ABCDEF</p>
+      <p region="r1" begin="00:00:00.31" end="00:00:04" xml:id="p1"><span style="s1">abcdef</span></p>
+      <p region="r2" begin="00:00:00.31" end="00:00:04" xml:id="p2"><span style="s1">ghijkl</span></p>
+      <p region="r3" begin="00:00:00.31" end="00:00:04" xml:id="p3"><span style="s1">mnopqr</span></p>
+      <p region="r4" begin="00:00:00.31" end="00:00:04" xml:id="p4"><span style="s1">stuvwy</span></p>
     </div>
   </body>
 </tt>

--- a/fail/dur006-fail.ttml
+++ b/fail/dur006-fail.ttml
@@ -2,11 +2,22 @@
 <!-- Available rendering time exceeded due to glyph drawing (cache unusued due to color change) -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="185%"/>
+      <style xml:id="s1" tts:color="#ff0000" tts:fontSize="185%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="0.5s" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
-      <p begin="0.5s" end="4s" tts:color="red" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.5" style="s0" xml:id="p0">あいうえおかきくけこさしすせそたち</p>
+      <p begin="00:00:00.5" end="00:00:04" style="s1" xml:id="p1">あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/fail/dur007-fail.ttml
+++ b/fail/dur007-fail.ttml
@@ -2,11 +2,22 @@
 <!-- Available rendering time exceeded due to glyph drawing (cache unusued due to font size change) -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="190%"/>
+      <style xml:id="s1" tts:fontSize="185%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="0.5s" tts:fontSize="190%">あいうえおかきくけこさしすせそたち</p>
-      <p begin="0.5s" end="4s" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.5" style="s0" xml:id="p0">あいうえおかきくけこさしすせそたち</p>
+      <p begin="00:00:00.5" end="00:00:04" style="s1" xml:id="p1">あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/fail/dur008-fail.ttml
+++ b/fail/dur008-fail.ttml
@@ -2,11 +2,22 @@
 <!-- Available rendering time exceeded due to glyph drawing (cache unusued due to font family change) -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="185%"/>
+      <style xml:id="s1" tts:fontFamily="proportionalSansSerif" tts:fontSize="185%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="0.5s" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
-      <p begin="0.5s" end="4s" tts:fontFamily="proportionalSansSerif" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.5" style="s0" xml:id="p0">あいうえおかきくけこさしすせそたち</p>
+      <p begin="00:00:00.5" end="00:00:04" style="s1" xml:id="p1">あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/fail/dur009-fail.ttml
+++ b/fail/dur009-fail.ttml
@@ -2,11 +2,22 @@
 <!-- Available rendering time exceeded due to glyph drawing (cache unusued due to font style change) -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="185%"/>
+      <style xml:id="s1" tts:fontStyle="italic" tts:fontSize="185%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="0.5s" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
-      <p begin="0.5s" end="4s" tts:fontStyle="italic" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.5" style="s0" xml:id="p0">あいうえおかきくけこさしすせそたち</p>
+      <p begin="00:00:00.5" end="00:00:04" style="s1" xml:id="p1">あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/fail/dur010-fail.ttml
+++ b/fail/dur010-fail.ttml
@@ -2,11 +2,22 @@
 <!-- Available rendering time exceeded due to glyph drawing (cache unusued due to font weight change) -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="185%"/>
+      <style xml:id="s1" tts:fontWeight="bold" tts:fontSize="185%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="0.5s" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
-      <p begin="0.5s" end="4s" tts:fontWeight="bold" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.5" style="s0" xml:id="p0">あいうえおかきくけこさしすせそたち</p>
+      <p begin="00:00:00.5" end="00:00:04" style="s1" xml:id="p1">あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/fail/dur011-fail.ttml
+++ b/fail/dur011-fail.ttml
@@ -2,11 +2,22 @@
 <!-- Available rendering time exceeded due to glyph drawing (cache unusued due to text decoration change) -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="185%"/>
+      <style xml:id="s1" tts:textDecoration="underline" tts:fontSize="185%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="0.5s" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
-      <p begin="0.5s" end="4s" tts:textDecoration="underline" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.5" style="s0" xml:id="p0">あいうえおかきくけこさしすせそたち</p>
+      <p begin="00:00:00.5" end="00:00:04" style="s1" xml:id="p1">あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/fail/dur012-fail.ttml
+++ b/fail/dur012-fail.ttml
@@ -2,11 +2,22 @@
 <!-- Available rendering time exceeded due to glyph drawing (cache unusued due to text outline change) -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="185%"/>
+      <style xml:id="s1" tts:textOutline="5%" tts:fontSize="185%"/> <!-- textOutline is not permitted in EBU-TT-D -->
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="0.5s" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
-      <p begin="0.5s" end="4s" tts:textOutline="5%" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.5" style="s0" xml:id="p0">あいうえおかきくけこさしすせそたち</p>
+      <p begin="00:00:00.5" end="00:00:04" style="s1" xml:id="p1">あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/fail/dur013-fail.ttml
+++ b/fail/dur013-fail.ttml
@@ -2,11 +2,22 @@
 <!-- Available rendering time exceeded due to glyph drawing (cache unusued due to text shadow change) -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="185%"/>
+      <style xml:id="s1" tts:textShadow="5% 5% red" tts:fontSize="185%"/> <!-- textShadow is not permitted in IMSC 1.0.1 or EBU-TT-D -->
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="0.5s" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
-      <p begin="0.5s" end="4s" tts:textShadow="5% 5% red" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.5" style="s0" xml:id="p0">あいうえおかきくけこさしすせそたち</p>
+      <p begin="00:00:00.5" end="00:00:04" style="s1" xml:id="p1">あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/fail/dur014-fail.ttml
+++ b/fail/dur014-fail.ttml
@@ -2,13 +2,21 @@
 <!-- Available rendering time exceeded due to glyph drawing (mix copy and draw) -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="200%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
   </head>
   <body>
-    <div>
-      <p begin="0s" end="0.2s" tts:fontSize="200%">abcdefg<br/>あいうえおかきくけ</p>
-      <p begin="0.6s" end="4s" tts:fontSize="200%">abcdefghijklmnopqrstuvwxyz<br/>あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.2" style="s0" xml:id="p0">abcdefg<br/>あいうえおかきくけ</p>
+      <p begin="00:00:00.6" end="00:00:04" style="s0" xml:id="p1">abcdefghijklmnopqrstuvwxyz<br/>あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/fail/ipd001-fail.ttml
+++ b/fail/ipd001-fail.ttml
@@ -2,12 +2,20 @@
 <!-- Max available rendering time (IPD) exceeded on initial ISD due to glyph drawing (CJK) -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="185%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
   </head>
   <body>
-    <div>
-      <p begin="0s" end="1s" tts:fontSize="185%">あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆ</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:01" style="s0" xml:id="p0">あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆ</p>
     </div>
   </body>
 </tt>

--- a/fail/ipd002-fail.ttml
+++ b/fail/ipd002-fail.ttml
@@ -2,12 +2,20 @@
 <!-- Max available rendering time (IPD) exceeded on initial ISD due to glyph copy (non-CJK) -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="300%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
   </head>
   <body>
-    <div>
-      <p begin="0s" end="1s" tts:fontSize="300%">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:01" style="s0" xml:id="p0">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</p>
     </div>
   </body>
 </tt>

--- a/fail/ipd003-fail.ttml
+++ b/fail/ipd003-fail.ttml
@@ -2,18 +2,20 @@
 <!-- Max available rendering time (IPD) exceeded on initial ISD due to background drawing -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
     <styling>
-      <style xml:id="s1" tts:backgroundColor="red" />
+      <style xml:id="s1" tts:backgroundColor="#ff0000"/>
     </styling>
     <layout>
-      <region xml:id="r1" style="s1"/>
+      <region xml:id="r1" tts:origin="0% 0%" tts:extent="100% 100%" style="s1"/>
     </layout>
   </head>
   <body>
     <div>
-      <p region="r1" begin="0s" end="1s"><span style="s1">a</span><span style="s1">b</span><span style="s1">c</span><span style="s1">d</span><span style="s1">e</span><span style="s1">f</span><span style="s1">g</span><span style="s1">h</span><span style="s1">i</span><span style="s1">j</span></p>
+      <p region="r1" begin="00:00:00" end="00:00:01" xml:id="p0"><span style="s1">a</span><span style="s1">b</span><span style="s1">c</span><span style="s1">d</span><span style="s1">e</span><span style="s1">f</span><span style="s1">g</span><span style="s1">h</span><span style="s1">i</span><span style="s1">j</span></p>
     </div>
   </body>
 </tt>

--- a/fail/ipd004-fail.ttml
+++ b/fail/ipd004-fail.ttml
@@ -2,13 +2,21 @@
 <!-- Max available rendering time (IPD) exceeded on non-initial ISD due to glyph drawing (CJK) -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="185%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
   </head>
   <body>
-    <div>
-      <p begin="0s" end="1s" tts:fontSize="185%">a</p>
-      <p begin="3s" end="4s" tts:fontSize="185%">あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆ</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:01" style="s0" xml:id="p0">a</p>
+      <p begin="00:00:03" end="00:00:04" style="s0" xml:id="p1">あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆ</p>
     </div>
   </body>
 </tt>

--- a/fail/ipd005-fail.ttml
+++ b/fail/ipd005-fail.ttml
@@ -2,13 +2,21 @@
 <!-- Max available rendering time (IPD) exceeded on non- initial ISD due to glyph copy (non-CJK) -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="300%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
   </head>
   <body>
-    <div>
-      <p begin="0s" end="1s">z</p>
-      <p begin="3s" end="4s" tts:fontSize="300%">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:01" xml:id="p0">z</p>
+      <p begin="00:00:03" end="00:00:04" style="s0" xml:id="p1">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</p>
     </div>
   </body>
 </tt>

--- a/fail/ipd006-fail.ttml
+++ b/fail/ipd006-fail.ttml
@@ -2,18 +2,21 @@
 <!-- Max available rendering time (IPD) exceeded on non-initial ISD due to background drawing -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
     <styling>
-      <style xml:id="s1" tts:backgroundColor="red" />
+      <style xml:id="s1" tts:backgroundColor="#ff0000"/>
     </styling>
     <layout>
-      <region xml:id="r1" style="s1"/>
+      <region xml:id="r1" tts:origin="0% 0%" tts:extent="100% 100%" style="s1"></region>
     </layout>
   </head>
   <body>
     <div>
-      <p region="r1" begin="3s" end="4s"><span style="s1">a</span><span style="s1">b</span><span style="s1">c</span><span style="s1">d</span><span style="s1">e</span><span style="s1">f</span><span style="s1">g</span><span style="s1">h</span><span style="s1">i</span><span style="s1">j</span></p>
+      <p begin="00:00:00" end="00:00:01" xml:id="p0">a</p>
+      <p region="r1" begin="00:00:03" end="00:00:04" xml:id="p1"><span style="s1">a</span><span style="s1">b</span><span style="s1">c</span><span style="s1">d</span><span style="s1">e</span><span style="s1">f</span><span style="s1">g</span><span style="s1">h</span><span style="s1">i</span><span style="s1">j</span></p>
     </div>
   </body>
 </tt>

--- a/fail/ipd006-fail.ttml
+++ b/fail/ipd006-fail.ttml
@@ -15,7 +15,6 @@
   </head>
   <body>
     <div>
-      <p begin="00:00:00" end="00:00:01" xml:id="p0">a</p>
       <p region="r1" begin="00:00:03" end="00:00:04" xml:id="p1"><span style="s1">a</span><span style="s1">b</span><span style="s1">c</span><span style="s1">d</span><span style="s1">e</span><span style="s1">f</span><span style="s1">g</span><span style="s1">h</span><span style="s1">i</span><span style="s1">j</span></p>
     </div>
   </body>

--- a/fail/ngbs001-fail.ttml
+++ b/fail/ngbs001-fail.ttml
@@ -2,10 +2,20 @@
 <!-- Glyph cache overrun (no glyph copy) -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="300%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="1s" tts:fontSize="300%">abcdefghijklmnopqrstuvwxyz</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:01" style="s0" xml:id="p0">abcdefghijklmnopqrstuvwxyz</p>
     </div>
   </body>
 </tt>

--- a/fail/ngbs002-fail.ttml
+++ b/fail/ngbs002-fail.ttml
@@ -2,11 +2,21 @@
 <!-- Glyph cache overrun (with glyph copy) -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="300%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="1s" tts:fontSize="300%">abcdefghijklmn</p>
-      <p begin="1s" end="2s" tts:fontSize="300%">bcdefghijklmnopqrstuvwxyzA</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:01" style="s0" xml:id="p0">abcdefghijklmn</p>
+      <p begin="00:00:01" end="00:00:02" style="s0" xml:id="p1">bcdefghijklmnopqrstuvwxyzA</p>
     </div>
   </body>
 </tt>

--- a/pass/dur001-pass.ttml
+++ b/pass/dur001-pass.ttml
@@ -1,14 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
-    xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+  xmlns="http://www.w3.org/ns/ttml"
+  xmlns:tts="http://www.w3.org/ns/ttml#styling"
+  xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+  ttp:timeBase="media">
   <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="185%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
   </head>
   <body>
-    <div>
-      <p begin="2.5s" end="3s" tts:fontSize="185%">a</p>
-      <p begin="3s" end="4s" tts:fontSize="185%">あいうえおかきくけこさしすせそた</p>
+    <div region="r0">
+      <p xml:id="p0" begin="00:00:02.5" end="00:00:03" style="s0">a</p>
+      <p xml:id="p1" begin="00:00:03" end="00:00:04" style="s0">あいうえおかきくけこさしすせそた</p>
     </div>
   </body>
 </tt>

--- a/pass/dur002-pass.ttml
+++ b/pass/dur002-pass.ttml
@@ -1,14 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
-    xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+  xmlns="http://www.w3.org/ns/ttml"
+  xmlns:tts="http://www.w3.org/ns/ttml#styling"
+  xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+  ttp:timeBase="media">
   <head>
+    <styling>
+      <style xml:id="s1" tts:fontSize="300%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
   </head>
   <body>
-    <div>
-      <p begin="2.5s" end="3s">z</p>
-      <p begin="3s" end="4s" tts:fontSize="300%">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</p>
+    <div region="r0">
+      <p xml:id="p0" begin="00:00:02.5" end="00:00:03">z</p>
+      <p xml:id="p1" begin="00:00:03" end="00:00:04" style="s1">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</p>
     </div>
   </body>
 </tt>

--- a/pass/dur003-pass.ttml
+++ b/pass/dur003-pass.ttml
@@ -15,7 +15,6 @@
   </head>
   <body>
     <div>
-      <p xml:id="p0" begin="00:00:02.5" end="00:00:03">z</p>
       <p xml:id="p1" region="r1" begin="00:00:03" end="00:00:04"><span style="s1">a</span><span style="s1">b</span><span style="s1">c</span></p>
     </div>
   </body>

--- a/pass/dur003-pass.ttml
+++ b/pass/dur003-pass.ttml
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
-    xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+  xmlns="http://www.w3.org/ns/ttml"
+  xmlns:tts="http://www.w3.org/ns/ttml#styling"
+  xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+  ttp:timeBase="media">
   <head>
     <styling>
-      <style xml:id="s1" tts:backgroundColor="red" />
+      <style xml:id="s1" tts:backgroundColor="#ff0000" />
     </styling>
     <layout>
-      <region xml:id="r1" style="s1"/>
+      <region xml:id="r1" tts:origin="0% 0%" tts:extent="100% 100%" style="s1"></region>
     </layout>
   </head>
   <body>
     <div>
-      <p region="r1" begin="3s" end="4s"><span style="s1">a</span><span style="s1">b</span><span style="s1">c</span></p>
+      <p xml:id="p0" begin="00:00:02.5" end="00:00:03">z</p>
+      <p xml:id="p1" region="r1" begin="00:00:03" end="00:00:04"><span style="s1">a</span><span style="s1">b</span><span style="s1">c</span></p>
     </div>
   </body>
 </tt>

--- a/pass/dur004-pass.ttml
+++ b/pass/dur004-pass.ttml
@@ -2,13 +2,21 @@
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
+    <styling>
+      <style xml:id="s1" tts:fontSize="300%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
   </head>
   <body>
-    <div>
-      <p begin="2.5s" end="3s" tts:fontSize="300%">a</p>
-      <p begin="3s" end="4s" tts:fontSize="300%">あああああああああああああああああああああああああああ</p>
+    <div region="r0">
+      <p xml:id="p0" begin="00:00:02.5" end="00:00:03" style="s1">a</p>
+      <p xml:id="p1" begin="00:00:03" end="00:00:04" style="s1">あああああああああああああああああああああああああああ</p>
     </div>
   </body>
 </tt>

--- a/pass/dur005-pass.ttml
+++ b/pass/dur005-pass.ttml
@@ -2,10 +2,12 @@
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
     <styling>
-      <style xml:id="s1" tts:backgroundColor="red" />
+      <style xml:id="s1" tts:backgroundColor="#ff0000" />
     </styling>
     <layout>
       <region xml:id="r1" style="s1" tts:extent="50% 50%" tts:origin="0% 0%"/>
@@ -16,11 +18,11 @@
   </head>
   <body>
     <div>
-      <p region="r4" begin="0s" end="0.2s">ABCDEF</p>
-      <p region="r1" begin="0.25s" end="4s"><span style="s1">a</span></p>
-      <p region="r2" begin="0.25s" end="4s"><span style="s1">g</span></p>
-      <p region="r3" begin="0.25s" end="4s"><span style="s1">m</span></p>
-      <p region="r4" begin="0.25s" end="4s"><span style="s1">s</span></p>
+      <p region="r4" begin="00:00:00" end="00:00:00.2" xml:id="p0">ABCDEF</p>
+      <p region="r1" begin="00:00:00.25" end="00:00:04" xml:id="p1"><span style="s1">a</span></p>
+      <p region="r2" begin="00:00:00.25" end="00:00:04" xml:id="p2"><span style="s1">g</span></p>
+      <p region="r3" begin="00:00:00.25" end="00:00:04" xml:id="p3"><span style="s1">m</span></p>
+      <p region="r4" begin="00:00:00.25" end="00:00:04" xml:id="p4"><span style="s1">s</span></p>
     </div>
   </body>
 </tt>

--- a/pass/dur006-pass.ttml
+++ b/pass/dur006-pass.ttml
@@ -2,11 +2,21 @@
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:color="#ff0000" tts:fontSize="185%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="0.5s" tts:color="red" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
-      <p begin="0.5s" end="4s" tts:color="red" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.5" style="s0" xml:id="p0">あいうえおかきくけこさしすせそたち</p>
+      <p begin="00:00:00.5" end="00:00:04" style="s0" xml:id="p1">あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/pass/dur007-pass.ttml
+++ b/pass/dur007-pass.ttml
@@ -1,12 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
-    xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+  xmlns="http://www.w3.org/ns/ttml"    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+  xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+  ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="185%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="0.5s" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
-      <p begin="0.5s" end="4s" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.5" style="s0" xml:id="p0">あいうえおかきくけこさしすせそたち</p>
+      <p begin="00:00:00.5" end="00:00:04" style="s0" xml:id="p1">あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/pass/dur008-pass.ttml
+++ b/pass/dur008-pass.ttml
@@ -2,11 +2,21 @@
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:fontFamily="proportionalSansSerif" tts:fontSize="185%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="0.5s" tts:fontFamily="proportionalSansSerif" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
-      <p begin="0.5s" end="4s" tts:fontFamily="proportionalSansSerif" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.5" style="s0" xml:id="p0">あいうえおかきくけこさしすせそたち</p>
+      <p begin="00:00:00.5" end="00:00:04" style="s0" xml:id="p1">あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/pass/dur009-pass.ttml
+++ b/pass/dur009-pass.ttml
@@ -2,11 +2,21 @@
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:fontStyle="italic" tts:fontSize="185%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="0.5s" tts:fontStyle="italic" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
-      <p begin="0.5s" end="4s" tts:fontStyle="italic" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.5" style="s0" xml:id="p0">あいうえおかきくけこさしすせそたち</p>
+      <p begin="00:00:00.5" end="00:00:04" style="s0" xml:id="p1">あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/pass/dur010-pass.ttml
+++ b/pass/dur010-pass.ttml
@@ -2,11 +2,21 @@
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:fontWeight="bold" tts:fontSize="185%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="0.5s" tts:fontWeight="bold" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
-      <p begin="0.5s" end="4s" tts:fontWeight="bold" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.5" style="s0" xml:id="p0">あいうえおかきくけこさしすせそたち</p>
+      <p begin="00:00:00.5" end="00:00:04" style="s0" xml:id="p1">あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/pass/dur011-pass.ttml
+++ b/pass/dur011-pass.ttml
@@ -2,11 +2,21 @@
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:textDecoration="underline" tts:fontSize="185%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="0.5s" tts:textDecoration="underline" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
-      <p begin="0.5s" end="4s" tts:textDecoration="underline" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.5" style="s0" xml:id="p0">あいうえおかきくけこさしすせそたち</p>
+      <p begin="00:00:00.5" end="00:00:04" style="s0" xml:id="p1">あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/pass/dur012-pass.ttml
+++ b/pass/dur012-pass.ttml
@@ -2,11 +2,21 @@
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:textOutline="5%" tts:fontSize="185%"/> <!-- textOutline is not permitted in EBU-TT-D -->
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="0.5s" tts:textOutline="5%" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
-      <p begin="0.5s" end="4s" tts:textOutline="5%" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.5" style="s0" xml:id="p0">あいうえおかきくけこさしすせそたち</p>
+      <p begin="00:00:00.5" end="00:00:04" style="s0" xml:id="p1">あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/pass/dur013-pass.ttml
+++ b/pass/dur013-pass.ttml
@@ -2,11 +2,21 @@
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:textShadow="5% 5% red" tts:fontSize="185%"/> <!-- textShadow is not permitted in IMSC 1.0.1 or EBU-TT-D -->
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="0.5s" tts:textShadow="5% 5% red" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
-      <p begin="0.5s" end="4s" tts:textShadow="5% 5% red" tts:fontSize="185%">あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.5" style="s0" xml:id="p0">あいうえおかきくけこさしすせそたち</p>
+      <p begin="00:00:00.5" end="00:00:04" style="s0" xml:id="p1">あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/pass/dur014-pass.ttml
+++ b/pass/dur014-pass.ttml
@@ -2,13 +2,21 @@
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="200%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
   </head>
   <body>
-    <div>
-      <p begin="0s" end="0.2s" tts:fontSize="200%">abcdefg<br/>あいうえおかきくけ</p>
-      <p begin="0.7s" end="4s" tts:fontSize="200%">abcdefghijklmnopqrstuvwxyz<br/>あいうえおかきくけこさしすせそたち</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.2" style="s0" xml:id="p0">abcdefg<br/>あいうえおかきくけ</p>
+      <p begin="00:00:00.7" end="00:00:04" style="s0" xml:id="p1">abcdefghijklmnopqrstuvwxyz<br/>あいうえおかきくけこさしすせそたち</p>
     </div>
   </body>
 </tt>

--- a/pass/dur015-pass.ttml
+++ b/pass/dur015-pass.ttml
@@ -2,15 +2,21 @@
 <!-- Short empty ISDs -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
+    <styling><style xml:id="s0"/></styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
   </head>
   <body>
-    <div>
-      <p begin="0s" end="0.15s">abcdefghij</p>
-      <p begin="0.19s" end="1s">ABCDEFGHIJ</p>
-      <p begin="1.04s" end="1.3s">abcdefghij</p>
-      <p begin="1.34s" end="2s">ABCDEFGHIJ</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:00.15" xml:id="p0">abcdefghij</p>
+      <p begin="00:00:00.19" end="00:00:01" xml:id="p1">ABCDEFGHIJ</p>
+      <p begin="00:00:01.04" end="00:00:01.3" xml:id="p2">abcdefghij</p>
+      <p begin="00:00:01.34" end="00:00:02" xml:id="p3">ABCDEFGHIJ</p>
     </div>
   </body>
 </tt>

--- a/pass/dur016-pass.ttml
+++ b/pass/dur016-pass.ttml
@@ -2,18 +2,24 @@
 <!-- Short successive ISDs -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
+    <styling><style xml:id="s0"/></styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
   </head>
   <body>
     <div>
-      <p begin="0s" end="0.1s">a</p>
-      <p begin="0.1s" end="0.2s">ab</p>
-      <p begin="0.2s" end="0.3s">abc</p>
-      <p begin="0.2s" end="0.3s">abcd</p>
-      <p begin="0.3s" end="0.4s">abcde</p>
-      <p begin="0.4s" end="0.5s">abcdef</p>
-      <p begin="0.5s" end="0.6s">abcdefg</p>
+      <p begin="00:00:00" end="00:00:00.1" xml:id="p0">a</p>
+      <p begin="00:00:00.1" end="00:00:00.2" xml:id="p1">ab</p>
+      <p begin="00:00:00.2" end="00:00:00.3" xml:id="p2">abc</p>
+      <p begin="00:00:00.2" end="00:00:00.3" xml:id="p3">abcd</p>
+      <p begin="00:00:00.3" end="00:00:00.4" xml:id="p4">abcde</p>
+      <p begin="00:00:00.4" end="00:00:00.5" xml:id="p5">abcdef</p>
+      <p begin="00:00:00.5" end="00:00:00.6" xml:id="p6">abcdefg</p>
     </div>
   </body>
 </tt>

--- a/pass/ipd001-pass.ttml
+++ b/pass/ipd001-pass.ttml
@@ -2,12 +2,20 @@
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="185%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
   </head>
   <body>
-    <div>
-      <p begin="0s" end="1s" tts:fontSize="185%">あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもや</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:01" style="s0" xml:id="p0">あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもや</p>
     </div>
   </body>
 </tt>

--- a/pass/ipd002-pass.ttml
+++ b/pass/ipd002-pass.ttml
@@ -2,12 +2,20 @@
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="300%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
   </head>
   <body>
-    <div>
-      <p begin="0s" end="1s" tts:fontSize="300%">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:01" style="s0" xml:id="p0">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</p>
     </div>
   </body>
 </tt>

--- a/pass/ipd003-pass.ttml
+++ b/pass/ipd003-pass.ttml
@@ -2,18 +2,20 @@
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
     <styling>
-      <style xml:id="s1" tts:backgroundColor="red" />
+      <style xml:id="s1" tts:backgroundColor="#ff0000"/>
     </styling>
     <layout>
-      <region xml:id="r1" style="s1"/>
+      <region xml:id="r1" tts:origin="0% 0%" tts:extent="100% 100%" style="s1"/>
     </layout>
   </head>
   <body>
     <div>
-      <p region="r1" begin="0s" end="1s"><span style="s1">a</span><span style="s1">b</span><span style="s1">c</span><span style="s1">d</span><span style="s1">e</span><span style="s1">f</span><span style="s1">g</span><span style="s1">h</span><span style="s1">i</span></p>
+      <p region="r1" begin="00:00:00" end="00:00:01" xml:id="p0"><span style="s1">a</span><span style="s1">b</span><span style="s1">c</span><span style="s1">d</span><span style="s1">e</span><span style="s1">f</span><span style="s1">g</span><span style="s1">h</span><span style="s1">i</span></p>
     </div>
   </body>
 </tt>

--- a/pass/ipd004-pass.ttml
+++ b/pass/ipd004-pass.ttml
@@ -2,13 +2,21 @@
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="185%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
   </head>
   <body>
-    <div>
-      <p begin="0s" end="1s" tts:fontSize="185%">a</p>
-      <p begin="3s" end="4s" tts:fontSize="185%">あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもや</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:01" style="s0" xml:id="p0">a</p>
+      <p begin="00:00:03" end="00:00:04" style="s0" xml:id="p1">あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもや</p>
     </div>
   </body>
 </tt>

--- a/pass/ipd005-pass.ttml
+++ b/pass/ipd005-pass.ttml
@@ -2,13 +2,21 @@
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="300%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
   </head>
   <body>
-    <div>
-      <p begin="0s" end="1s">z</p>
-      <p begin="3s" end="4s" tts:fontSize="300%">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:01" xml:id="p0">z</p>
+      <p begin="00:00:03" end="00:00:04" style="s0" xml:id="p1">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</p>
     </div>
   </body>
 </tt>

--- a/pass/ipd006-pass.ttml
+++ b/pass/ipd006-pass.ttml
@@ -15,7 +15,6 @@
   </head>
   <body>
     <div>
-      <p begin="00:00:00" end="00:00:01" xml:id="p0">a</p>
       <p region="r1" begin="00:00:03" end="00:00:04" xml:id="p1"><span style="s1">a</span><span style="s1">b</span><span style="s1">c</span><span style="s1">d</span><span style="s1">e</span><span style="s1">f</span><span style="s1">g</span><span style="s1">h</span><span style="s1">i</span></p>
     </div>
   </body>

--- a/pass/ipd006-pass.ttml
+++ b/pass/ipd006-pass.ttml
@@ -2,18 +2,21 @@
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
   <head>
     <styling>
-      <style xml:id="s1" tts:backgroundColor="red" />
+      <style xml:id="s1" tts:backgroundColor="#ff0000"/>
     </styling>
     <layout>
-      <region xml:id="r1" style="s1"/>
+      <region xml:id="r1" tts:origin="0% 0%" tts:extent="100% 100%" style="s1"></region>
     </layout>
   </head>
   <body>
     <div>
-      <p region="r1" begin="3s" end="4s"><span style="s1">a</span><span style="s1">b</span><span style="s1">c</span><span style="s1">d</span><span style="s1">e</span><span style="s1">f</span><span style="s1">g</span><span style="s1">h</span><span style="s1">i</span></p>
+      <p begin="00:00:00" end="00:00:01" xml:id="p0">a</p>
+      <p region="r1" begin="00:00:03" end="00:00:04" xml:id="p1"><span style="s1">a</span><span style="s1">b</span><span style="s1">c</span><span style="s1">d</span><span style="s1">e</span><span style="s1">f</span><span style="s1">g</span><span style="s1">h</span><span style="s1">i</span></p>
     </div>
   </body>
 </tt>

--- a/pass/ngbs001-pass.ttml
+++ b/pass/ngbs001-pass.ttml
@@ -2,10 +2,20 @@
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="300%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="1s" tts:fontSize="300%">abcdefghijklmnopqrstuvwx</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:01" style="s0" xml:id="p0">abcdefghijklmnopqrstuvwx</p>
     </div>
   </body>
 </tt>

--- a/pass/ngbs002-pass.ttml
+++ b/pass/ngbs002-pass.ttml
@@ -2,11 +2,21 @@
 <!-- See corresponding fail test -->
 <tt xml:lang="en"
     xmlns="http://www.w3.org/ns/ttml"
-    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="s0" tts:fontSize="300%"/>
+    </styling>
+    <layout>
+      <region xml:id="r0" tts:origin="0% 0%" tts:extent="100% 100%"></region>
+    </layout>
+  </head>
   <body>
-    <div>
-      <p begin="0s" end="1s" tts:fontSize="300%">abcdefghijklmn</p>
-      <p begin="1s" end="2s" tts:fontSize="300%">bcdefghijklmnopqrstuvwxy</p>
+    <div region="r0">
+      <p begin="00:00:00" end="00:00:01" style="s0" xml:id="p0">abcdefghijklmn</p>
+      <p begin="00:00:01" end="00:00:02" style="s0" xml:id="p1">bcdefghijklmnopqrstuvwxy</p>
     </div>
   </body>
 </tt>


### PR DESCRIPTION
Fixes #3 and addresses #4 by making the tests EBU-TT-D conformant where possible and adding XML comments where content is not compatible with EBU-TT-D or specified versions of IMSC.