### PR TITLE
Reduce available time for 2nd ISD to 0.5s

### DIFF
--- a/fail/dur003-fail.ttml
+++ b/fail/dur003-fail.ttml
@@ -15,6 +15,7 @@
   </head>
   <body>
     <div>
+      <p xml:id="p0" region="r1" begin="00:00:02.5" end="00:00:03">z</p>
       <p xml:id="p1" region="r1" begin="00:00:03" end="00:00:04"><span style="s1">a</span><span style="s1">b</span><span style="s1">c</span><span style="s1">d</span></p>
     </div>
   </body>

--- a/pass/dur003-pass.ttml
+++ b/pass/dur003-pass.ttml
@@ -15,6 +15,7 @@
   </head>
   <body>
     <div>
+      <p xml:id="p0" region="r1" begin="00:00:02.5" end="00:00:03">z</p>
       <p xml:id="p1" region="r1" begin="00:00:03" end="00:00:04"><span style="s1">a</span><span style="s1">b</span><span style="s1">c</span></p>
     </div>
   </body>


### PR DESCRIPTION
Fixes #9 by reducing the available rendering duration of the second ISD to 0.5s.